### PR TITLE
Add CACHE_SQLITE_TTL_JITTER_SECONDS environment variable to z2k2 service

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -118,6 +118,7 @@ services:
     environment:
       - CACHE_SQLITE_PATH=/app/data/cache.db
       - CACHE_SQLITE_TTL_SECONDS=3600
+      - CACHE_SQLITE_TTL_JITTER_SECONDS=300
     ports:
       - "8081:8000"
     volumes:


### PR DESCRIPTION
Set jitter to 300 seconds (5 minutes) to randomize cache expiration
and prevent simultaneous cache expirations across instances.